### PR TITLE
Add checks for Toeplitz and circulant matrices.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -22,6 +22,7 @@ doctest_global_setup = """
 import ifnt
 import jax
 from jax import numpy as jnp
+from jax import scipy as jsp
 """
 doctest_default_flags = (
     doctest.ELLIPSIS | doctest.DONT_ACCEPT_TRUE_FOR_1 | doctest.NORMALIZE_WHITESPACE


### PR DESCRIPTION
This PR adds four new functions:

- `is_toeplitz` and `assert_toeplitz` to check and assert that a batch of matrices is [Toeplitz](https://en.wikipedia.org/wiki/Toeplitz_matrix).
- `is_circulant` and `assert_circulant` to check and assert that a batch of matrices is [circulant](https://en.wikipedia.org/wiki/Circulant_matrix).