### PR TITLE
Skip `index_guard` if at least one of array and index are traced.

### DIFF
--- a/ifnt/random.py
+++ b/ifnt/random.py
@@ -39,7 +39,7 @@ def _wrap_random(func: C) -> C:
 
     @functools.wraps(func)
     def _inner(self: "JaxRandomState", *args, **kwargs):
-        return func(next(self.keys), *args, **kwargs)
+        return func(self.get_key(), *args, **kwargs)
 
     return _inner
 

--- a/ifnt/util.py
+++ b/ifnt/util.py
@@ -169,7 +169,7 @@ class index_guard:
     Safe indexing that checks out of bounds when not traced.
 
     Args:
-        ACTUAL: array to guard.
+        x: Array to guard.
 
     Example:
 
@@ -192,7 +192,7 @@ class index_guard:
     def __getitem__(self, index):
         # Get the underlying array if `x` is an index helper obtained using `x.at`.
         array: jnp.ndarray = getattr(self.x, "array", self.x)
-        if not is_traced(array) and self.ACTIVE:
+        if not is_traced(array, index) and self.ACTIVE:
             # Create a dummy array with the right shape.
             shape = array.shape
             strides = (0,) * array.ndim

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "jax-ifnt"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
     "jax",
     "jaxlib",


### PR DESCRIPTION
Fixes a bug when the array is static but the index is traced.